### PR TITLE
feat: add initial Prisma schema and seed data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "parkly",
+  "version": "1.0.0",
+  "description": "Aplicación diseñada para administrar entradas y salidas de vehículos en parqueos. Permite registrar tiempos de uso y generar el cobro automáticamente, con soporte para pagos digitales y reportes de control.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo 'No tests'",
+    "seed": "ts-node prisma/seed.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@prisma/client": "^5.15.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.15.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/prisma/migrations/000_init/migration.sql
+++ b/prisma/migrations/000_init/migration.sql
@@ -1,0 +1,38 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "email" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'USER'
+);
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateTable
+CREATE TABLE "Rate" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "price" REAL NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "userId" INTEGER NOT NULL,
+    "rateId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Ticket_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Ticket_rateId_fkey" FOREIGN KEY ("rateId") REFERENCES "Rate"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Payment" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "ticketId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "amount" REAL NOT NULL,
+    "paidAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Payment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Payment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+CREATE UNIQUE INDEX "Payment_ticketId_key" ON "Payment"("ticketId");
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,50 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+enum Role {
+  ADMIN
+  OPERATOR
+  USER
+}
+
+model User {
+  id       Int      @id @default(autoincrement())
+  email    String   @unique
+  name     String
+  role     Role     @default(USER)
+  tickets  Ticket[]
+  payments Payment[]
+}
+
+model Rate {
+  id      Int      @id @default(autoincrement())
+  name    String
+  price   Float
+  tickets Ticket[]
+}
+
+model Ticket {
+  id        Int       @id @default(autoincrement())
+  user      User      @relation(fields: [userId], references: [id])
+  userId    Int
+  rate      Rate      @relation(fields: [rateId], references: [id])
+  rateId    Int
+  payment   Payment?
+  createdAt DateTime  @default(now())
+}
+
+model Payment {
+  id       Int      @id @default(autoincrement())
+  ticket   Ticket   @relation(fields: [ticketId], references: [id])
+  ticketId Int      @unique
+  user     User     @relation(fields: [userId], references: [id])
+  userId   Int
+  amount   Float
+  paidAt   DateTime @default(now())
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,45 @@
+import { PrismaClient, Role } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const admin = await prisma.user.upsert({
+    where: { email: 'admin@example.com' },
+    update: {},
+    create: {
+      email: 'admin@example.com',
+      name: 'Admin',
+      role: Role.ADMIN,
+    },
+  });
+
+  const operator = await prisma.user.upsert({
+    where: { email: 'operator@example.com' },
+    update: {},
+    create: {
+      email: 'operator@example.com',
+      name: 'Operator',
+      role: Role.OPERATOR,
+    },
+  });
+
+  const rate = await prisma.rate.upsert({
+    where: { name: 'Base Rate' },
+    update: {},
+    create: {
+      name: 'Base Rate',
+      price: 10.0,
+    },
+  });
+
+  console.log({ admin, operator, rate });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "outDir": "dist"
+  },
+  "include": ["prisma/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- set up Prisma schema for users, rates, tickets and payments with role enum and relations
- add initial SQLite migration and seed script for admin, operator and base rate
- configure package for Prisma and TypeScript tooling

## Testing
- `npx prisma migrate dev --name init` *(fails: 403 Forbidden to registry.npmjs.org)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b21803d6bc832eac51d87fdc09e248